### PR TITLE
Unset md5'd url

### DIFF
--- a/src/Tracker/Manager.php
+++ b/src/Tracker/Manager.php
@@ -60,7 +60,7 @@ class Manager
             if (count(array_intersect($tags, $storeTags)) > 0) {
                 $urls[] = $url;
 
-                unset($storeData[$url]);
+                unset($storeData[$key]);
             }
         }
 


### PR DESCRIPTION
In [L63 of the Manager](https://github.com/thoughtco/statamic-cache-tracker/blob/8f74e90fb3087011425fdbddef1ec695e0d29eb2/src/Tracker/Manager.php#L63) the data of the to-be-invalidated url is supposed to be unset from the $storeData array via `unset($storeData[$url]);`. 

However in L18 the urls are added not with the URL as the array key, but the _md5'd URL_. Hence, the data is never unset. In L63 that would mean using the $key var instead: `unset($storeData[$key]);`. This should properly unset the data from the array, before it is stored in the cache again.