### PR TITLE
Handle `Form` instances when tracking forms tag

### DIFF
--- a/src/Http/Middleware/CacheTracker.php
+++ b/src/Http/Middleware/CacheTracker.php
@@ -127,8 +127,14 @@ class CacheTracker
                 return $next($value);
             }
 
-            $handle = $this->params->get('in') ? 'form:'.$this->params->get('in') : $this->tag;
-            $self->addContentTag($handle);
+            if ($form = $this->params->get('in')) {
+                $form = is_string($form) ? $form : $form->handle();
+                $self->addContentTag('form:'.$form);
+
+                return $next($value);
+            }
+
+            $self->addContentTag($this->tag);
 
             return $next($value);
         });


### PR DESCRIPTION
This pull request fixes an issue I just found where the Cache Tracker wasn't expecting `Form` instances to be passed into the form tag's `in` parameter.

For example, this syntax causes an error:

```antlers
{{ form:create :in="registration_form" }}
```

Whereas, this syntax would work:

```antlers
{{ form:create :in="registration_form:handle" }}
```