### PR TITLE
Reset store then invalidate urls

### DIFF
--- a/src/Tracker/Manager.php
+++ b/src/Tracker/Manager.php
@@ -75,9 +75,9 @@ class Manager
         }
 
         if (! empty($urls)) {
-            $this->invalidateUrls($urls);
-
             $this->cacheStore()->forever($this->cacheKey, $storeData);
+
+            $this->invalidateUrls($urls);
         }
 
         return $this;


### PR DESCRIPTION
This PR fixes a bug where (when not using queues) the tracker store would be reset after the URL was invalidated and potentially called, therefore the tracker store would never update.

To resolve this we reset the tracker store before invalidating the URLs.