### PR TITLE
Add augmentation hook for Page class

### DIFF
--- a/src/Http/Middleware/CacheTracker.php
+++ b/src/Http/Middleware/CacheTracker.php
@@ -11,6 +11,7 @@ use Statamic\Contracts\Entries\Entry;
 use Statamic\Contracts\Globals\Variables;
 use Statamic\Facades\URL;
 use Statamic\Forms;
+use Statamic\Structures\Page;
 use Statamic\Support\Str;
 use Statamic\Tags;
 use Statamic\Taxonomies\LocalizedTerm;
@@ -96,6 +97,16 @@ class CacheTracker
         app(Entry::class)::hook('augmented', function ($augmented, $next) use ($self, $url) {
             if ($this->absoluteUrl() != $url) {
                 $self->addContentTag($this->collection()->handle().':'.$this->id());
+            }
+
+            return $next($augmented);
+        });
+
+        Page::hook('augmented', function ($augmented, $next) use ($self, $url) {
+            $entry = $this->entry();
+
+            if ($entry && $entry->absoluteUrl() != $url) {
+                $self->addContentTag($entry->collection()->handle().':'.$entry->id());
             }
 
             return $next($augmented);


### PR DESCRIPTION
I have a template that loops through child pages of a structured collection with the `{{ children }}` tag. Unfortunately, the augmentation hook doesn't trigger and the child pages are not added as tags to the CacheTracker. Adding the hook for the `Statamic\Structures\Page`-class fixes that.