### PR TITLE
Make content tags unique

### DIFF
--- a/src/Http/Middleware/CacheTracker.php
+++ b/src/Http/Middleware/CacheTracker.php
@@ -48,7 +48,7 @@ class CacheTracker
         $response = $next($request);
 
         if ($this->content) {
-            Tracker::add($url, $this->content);
+            Tracker::add($url, array_unique($this->content));
         }
 
         return $response;


### PR DESCRIPTION
To prevent excess data being added to the manifest, only store unique tag values.