### PR TITLE
Add support for adding tags by dispatching an event

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ class AdditionalTrackerClass {
 Tracker::addAdditionalTracker(AdditionalTrackerClass::class);
 ```
 
+#### Dispatching an event
+
+```php
+Thoughtco\StatamicCacheTracker\Events\TrackContentTags::dispatch(['additional::tag']);
+```
+
 ### Invalidating tracked data
 To invalidate pages containing your tracked data, use a listener or observer, and call:         
 

--- a/src/Events/TrackContentTags.php
+++ b/src/Events/TrackContentTags.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Events;
+
+use Statamic\Events\Event;
+
+class TrackContentTags extends Event
+{
+    public function __construct(public array $tags) {}
+}

--- a/src/Http/Middleware/CacheTracker.php
+++ b/src/Http/Middleware/CacheTracker.php
@@ -5,6 +5,7 @@ namespace Thoughtco\StatamicCacheTracker\Http\Middleware;
 use Closure;
 use Illuminate\Pipeline\Pipeline;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Event;
 use Livewire\Livewire;
 use Statamic\Contracts\Assets\Asset;
 use Statamic\Contracts\Entries\Entry;
@@ -15,6 +16,7 @@ use Statamic\Structures\Page;
 use Statamic\Support\Str;
 use Statamic\Tags;
 use Statamic\Taxonomies\LocalizedTerm;
+use Thoughtco\StatamicCacheTracker\Events\TrackContentTags;
 use Thoughtco\StatamicCacheTracker\Facades\Tracker;
 
 class CacheTracker
@@ -44,6 +46,10 @@ class CacheTracker
             ->setupTagHooks()
             ->setupAugmentationHooks($url)
             ->setupAdditionalTracking();
+
+        Event::listen(function (TrackContentTags $event) {
+            $this->content = array_merge($this->content, $event->tags ?? []);
+        });
 
         $response = $next($request);
 

--- a/tests/Unit/EventListenerTest.php
+++ b/tests/Unit/EventListenerTest.php
@@ -18,6 +18,7 @@ class EventListenerTest extends TestCase
 
         $next = function () {
             TrackContentTags::dispatch(['test::tag']);
+
             return response('');
         };
 

--- a/tests/Unit/EventListenerTest.php
+++ b/tests/Unit/EventListenerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Tests\Unit;
+
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+use Thoughtco\StatamicCacheTracker\Events\TrackContentTags;
+use Thoughtco\StatamicCacheTracker\Facades\Tracker;
+use Thoughtco\StatamicCacheTracker\Http\Middleware\CacheTracker;
+use Thoughtco\StatamicCacheTracker\Tests\TestCase;
+
+class EventListenerTest extends TestCase
+{
+    #[Test]
+    public function it_tracks_tags_from_events()
+    {
+        $request = Request::create('/');
+
+        $next = function () {
+            TrackContentTags::dispatch(['test::tag']);
+            return response('');
+        };
+
+        $middleware = new CacheTracker();
+        $response = $middleware->handle($request, $next);
+
+        $this->assertSame(['test::tag'], collect(Tracker::all())->firstWhere('url', 'http://localhost/')['tags']);
+    }
+}


### PR DESCRIPTION
This PR adds support for adding tags by dispatching an event, for example within a custom controller:

```php
public function index() 
{
	\Thoughtco\StatamicCacheTracker\Events\TrackContentTags::dispatch(['additional::tag']);
}
```