### PR TITLE
Fire invalidation as a job so it can be queued

### DIFF
--- a/src/Jobs/InvalidateTags.php
+++ b/src/Jobs/InvalidateTags.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Thoughtco\StatamicCacheTracker\Facades\Tracker;
+
+class InvalidateTags implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function __construct(public array $tags) {}
+
+    public function handle(): void
+    {
+        Tracker::invalidate($this->tags);
+    }
+}

--- a/src/Listeners/Subscriber.php
+++ b/src/Listeners/Subscriber.php
@@ -4,6 +4,7 @@ namespace Thoughtco\StatamicCacheTracker\Listeners;
 
 use Statamic\Events;
 use Thoughtco\StatamicCacheTracker\Facades\Tracker;
+use Thoughtco\StatamicCacheTracker\Jobs\InvalidateTags;
 
 class Subscriber
 {
@@ -115,6 +116,6 @@ class Subscriber
 
     private function invalidateContent($tags)
     {
-        Tracker::invalidate($tags);
+        InvalidateTags::dispatch($tags);
     }
 }


### PR DESCRIPTION
This PR moves tag invalidation to a job so that it can be queued and not affect the update speed within the CP.