### PR TITLE
Add ContentTracked event to make testing simpler

### DIFF
--- a/src/Events/ContentTracked.php
+++ b/src/Events/ContentTracked.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Events;
+
+use Statamic\Events\Event;
+
+class ContentTracked extends Event
+{
+    public function __construct(public string $url, public array $tags) {}
+}

--- a/src/Http/Middleware/CacheTracker.php
+++ b/src/Http/Middleware/CacheTracker.php
@@ -41,10 +41,10 @@ class CacheTracker
             return $next($request);
         }
 
-        $cacher = false;
+        $cacher = app(Cacher::class);
 
-        if (app()->environment() != 'testing') {
-            $cacher = app(Cacher::class);
+        if ($cacher && $cacher->hasCachedPage($request)) {
+            return $next($request);
         }
 
         $url = $this->url();
@@ -63,10 +63,6 @@ class CacheTracker
         });
 
         $response = $next($request);
-
-        if ($cacher && ! $cacher->hasCachedPage($request)) {
-            return $response;
-        }
 
         if ($this->content) {
             Tracker::add($url, array_unique($this->content));

--- a/src/Tracker/Manager.php
+++ b/src/Tracker/Manager.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Cache;
 use InvalidArgumentException;
 use Statamic\StaticCaching\Cacher;
+use Thoughtco\StatamicCacheTracker\Events\ContentTracked;
 
 class Manager
 {
@@ -23,6 +24,8 @@ class Manager
         ];
 
         $this->cacheStore()->forever($this->cacheKey, $storeData);
+
+        ContentTracked::dispatch($url, $tags);
 
         return $this;
     }

--- a/tests/Unit/TrackerTest.php
+++ b/tests/Unit/TrackerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Tests\Unit;
+
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Thoughtco\StatamicCacheTracker\Events\ContentTracked;
+use Thoughtco\StatamicCacheTracker\Facades\Tracker;
+use Thoughtco\StatamicCacheTracker\Tests\TestCase;
+
+class TrackerTest extends TestCase
+{
+    #[Test]
+    public function it_tracks_uncached_pages()
+    {
+        Event::fake();
+
+        Tracker::addAdditionalTracker(function ($tracker, $next) {
+            $tracker->addContentTag('test::tag');
+        });
+
+        $this->get('/');
+
+        $this->assertSame(['test::tag'], collect(Tracker::all())->first()['tags']);
+
+        Event::assertDispatched(ContentTracked::class, 1);
+    }
+
+    #[Test]
+    public function it_doesnt_track_already_cached_pages()
+    {
+        Event::fake();
+
+        Tracker::addAdditionalTracker(function ($tracker, $next) {
+            $tracker->addContentTag('test::tag');
+        });
+
+        $this->get('/');
+
+        $this->assertSame(['test::tag'], collect(Tracker::all())->first()['tags']);
+
+        $this->get('/');
+
+        $this->assertSame(['test::tag'], collect(Tracker::all())->first()['tags']);
+
+        Event::assertDispatched(ContentTracked::class, 1);
+    }
+
+    #[Test]
+    public function it_doesnt_track_pages_already_in_the_manifest()
+    {
+        Event::fake();
+
+        Tracker::add('/', ['some:thing']);
+
+        Tracker::addAdditionalTracker(function ($tracker, $next) {
+            $tracker->addContentTag('test::tag');
+        });
+
+        $this->get('/');
+
+        $this->assertSame(['some:thing'], collect(Tracker::all())->first()['tags']);
+    }
+}


### PR DESCRIPTION
This PR fixes regressions introduced in #16 and adds test coverage to make sure it doesn't regress again