### PR TITLE
Change of approach for handling lack of wasStaticallyCached()

### DIFF
--- a/src/Http/Middleware/CacheTracker.php
+++ b/src/Http/Middleware/CacheTracker.php
@@ -68,8 +68,12 @@ class CacheTracker
             return $response;
         }
 
-        if (is_callable([$response, 'wasStaticallyCached']) && $response->wasStaticallyCached()) {
-            return $response;
+        try {
+            if ($response->wasStaticallyCached()) {
+                return $response;
+            }
+        } catch (\Throwable $e) {
+
         }
 
         if ($this->content) {


### PR DESCRIPTION
is_callable didnt seem to be sufficient, so opt for a try/catch instead.