### PR TITLE
Add CLI for flush/invalidate/list

### DIFF
--- a/src/Commands/Flush.php
+++ b/src/Commands/Flush.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Commands;
+
+use Illuminate\Console\Command;
+use Thoughtco\StatamicCacheTracker\Facades\Tracker;
+
+class Flush extends Command
+{
+    protected $signature = 'cache-tracker:flush';
+
+    protected $description = 'Flush all tracked URLs from the cache tracker';
+
+    public function handle()
+    {
+        $count = count(Tracker::all());
+
+        Tracker::flush();
+
+        $this->info("Flushed {$count} tracked URL(s).");
+    }
+}

--- a/src/Commands/Invalidate.php
+++ b/src/Commands/Invalidate.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Commands;
+
+use Illuminate\Console\Command;
+use Thoughtco\StatamicCacheTracker\Facades\Tracker;
+
+class Invalidate extends Command
+{
+    protected $signature = 'cache-tracker:invalidate {url : The URL to remove from the cache tracker}';
+
+    protected $description = 'Remove a URL from the cache tracker and invalidate it from the static cache';
+
+    public function handle()
+    {
+        $url = $this->argument('url');
+
+        if (! Tracker::has($url)) {
+            $this->warn("URL not found in tracker: {$url}");
+
+            return 1;
+        }
+
+        Tracker::remove($url);
+
+        $this->info("Invalidated: {$url}");
+    }
+}

--- a/src/Commands/ListUrls.php
+++ b/src/Commands/ListUrls.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Commands;
+
+use Illuminate\Console\Command;
+use Thoughtco\StatamicCacheTracker\Facades\Tracker;
+
+class ListUrls extends Command
+{
+    protected $signature = 'cache-tracker:list {--url= : Filter by URL (supports * wildcard)}';
+
+    protected $description = 'List all tracked URLs and their cache tags';
+
+    public function handle()
+    {
+        $all = collect(Tracker::all());
+
+        if ($filter = $this->option('url')) {
+            $prefix = rtrim($filter, '*');
+            $all = $all->filter(fn ($data) => str_starts_with($data['url'], $prefix));
+        }
+
+        if ($all->isEmpty()) {
+            $this->info('No tracked URLs found.');
+
+            return;
+        }
+
+        $this->table(
+            ['URL', 'Tags'],
+            $all->map(fn ($data) => [$data['url'], implode(', ', $data['tags'])])->values()
+        );
+
+        $this->info("Total: {$all->count()} URL(s)");
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,6 +9,12 @@ use Thoughtco\StatamicCacheTracker\Http\Controllers\UtilityController;
 
 class ServiceProvider extends AddonServiceProvider
 {
+    protected $commands = [
+        Commands\Flush::class,
+        Commands\Invalidate::class,
+        Commands\ListUrls::class,
+    ];
+
     protected $actions = [
         Actions\ClearCache::class,
         Actions\ViewCacheTags::class,

--- a/tests/Unit/CommandsTest.php
+++ b/tests/Unit/CommandsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Tests\Unit;
+
+use PHPUnit\Framework\Attributes\Test;
+use Thoughtco\StatamicCacheTracker\Facades\Tracker;
+use Thoughtco\StatamicCacheTracker\Tests\TestCase;
+
+class CommandsTest extends TestCase
+{
+    #[Test]
+    public function flush_command_clears_all_tracked_urls()
+    {
+        Tracker::add('/page1', ['products:1']);
+        Tracker::add('/page2', ['products:2']);
+
+        $this->assertCount(2, Tracker::all());
+
+        $this->artisan('cache-tracker:flush')
+            ->expectsOutput('Flushed 2 tracked URL(s).')
+            ->assertExitCode(0);
+
+        $this->assertCount(0, Tracker::all());
+    }
+
+    #[Test]
+    public function flush_command_reports_zero_when_nothing_tracked()
+    {
+        $this->artisan('cache-tracker:flush')
+            ->expectsOutput('Flushed 0 tracked URL(s).')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function invalidate_command_removes_url()
+    {
+        Tracker::add('/page1', ['products:1']);
+        Tracker::add('/page2', ['products:2']);
+
+        $this->artisan('cache-tracker:invalidate', ['url' => '/page1'])
+            ->expectsOutput('Invalidated: /page1')
+            ->assertExitCode(0);
+
+        $this->assertCount(1, Tracker::all());
+        $this->assertNull(Tracker::get('/page1'));
+        $this->assertNotNull(Tracker::get('/page2'));
+    }
+
+    #[Test]
+    public function invalidate_command_warns_when_url_not_found()
+    {
+        $this->artisan('cache-tracker:invalidate', ['url' => '/not-tracked'])
+            ->expectsOutput('URL not found in tracker: /not-tracked')
+            ->assertExitCode(1);
+    }
+
+    #[Test]
+    public function list_command_shows_all_tracked_urls()
+    {
+        Tracker::add('/page1', ['products:1', 'category:electronics']);
+        Tracker::add('/page2', ['products:2']);
+
+        $this->artisan('cache-tracker:list')
+            ->expectsTable(['URL', 'Tags'], [
+                ['/page1', 'products:1, category:electronics'],
+                ['/page2', 'products:2'],
+            ])
+            ->expectsOutput('Total: 2 URL(s)')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function list_command_shows_message_when_nothing_tracked()
+    {
+        $this->artisan('cache-tracker:list')
+            ->expectsOutput('No tracked URLs found.')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function list_command_filters_by_url_prefix()
+    {
+        Tracker::add('/blog/post-1', ['entries:1']);
+        Tracker::add('/blog/post-2', ['entries:2']);
+        Tracker::add('/about', ['entries:3']);
+
+        $this->artisan('cache-tracker:list', ['--url' => '/blog/*'])
+            ->expectsTable(['URL', 'Tags'], [
+                ['/blog/post-1', 'entries:1'],
+                ['/blog/post-2', 'entries:2'],
+            ])
+            ->expectsOutput('Total: 2 URL(s)')
+            ->assertExitCode(0);
+    }
+
+    #[Test]
+    public function list_command_filter_returns_no_results_message()
+    {
+        Tracker::add('/page1', ['products:1']);
+
+        $this->artisan('cache-tracker:list', ['--url' => '/blog/*'])
+            ->expectsOutput('No tracked URLs found.')
+            ->assertExitCode(0);
+    }
+}


### PR DESCRIPTION
Adds three commands for managing the cache tracker outside of the Control Panel, useful for deployment scripts, scheduled tasks, and debugging.

Commands
- `cache-tracker:flush` — Invalidates and removes all tracked URLs from the tracker
- `cache-tracker:invalidate {url}` — Removes a single URL from the tracker and invalidates it from the static cache; exits with code 1 if the URL isn't tracked
- `cache-tracker:list [--url=]` — Displays a table of all tracked URLs and their tags; accepts an optional --url flag with wildcard prefix support (e.g. --url=https://example.com/blog/*) to filter results
