### PR TITLE
Add `cache_tracker` tag

### DIFF
--- a/src/Tags/CacheTracker.php
+++ b/src/Tags/CacheTracker.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Tags;
+
+use Statamic\Tags\Tags;
+use Thoughtco\StatamicCacheTracker\Events\TrackContentTags;
+
+class CacheTracker extends Tags
+{
+    /**
+     * {{ cache_tracker tag="hero" }}
+     */
+    public function index(): void
+    {
+        $this->track($this->params->get('tag'));
+    }
+
+    /**
+     * {{ cache_tracker:hero }}
+     */
+    public function wildcard(string $method): void
+    {
+        $this->track($method);
+    }
+
+    private function track(?string $tag): void
+    {
+        if (! is_null($tag)) {
+            TrackContentTags::dispatch([$tag]);
+        }
+    }
+}

--- a/tests/Unit/CacheTrackerTagTest.php
+++ b/tests/Unit/CacheTrackerTagTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Thoughtco\StatamicCacheTracker\Tests\Unit;
+
+use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Test;
+use Statamic\Facades\Antlers;
+use Thoughtco\StatamicCacheTracker\Events\TrackContentTags;
+use Thoughtco\StatamicCacheTracker\Tests\TestCase;
+
+class CacheTrackerTagTest extends TestCase
+{
+    #[Test]
+    public function it_tracks_a_tag_via_the_tag_parameter()
+    {
+        Event::fake([TrackContentTags::class]);
+
+        Antlers::parse('{{ cache_tracker tag="custom:dependency" }}', [], true);
+
+        $this->assertTracked(['custom:dependency']);
+    }
+
+    #[Test]
+    public function it_tracks_a_tag_via_the_wildcard_method()
+    {
+        Event::fake([TrackContentTags::class]);
+
+        Antlers::parse('{{ cache_tracker:custom:dependency }}', [], true);
+
+        $this->assertTracked(['custom:dependency']);
+    }
+
+    #[Test]
+    public function it_does_not_track_when_no_tag_is_given()
+    {
+        Event::fake([TrackContentTags::class]);
+
+        Antlers::parse('{{ cache_tracker }}', [], true);
+
+        Event::assertNotDispatched(TrackContentTags::class);
+    }
+
+    private function assertTracked(array $tags): void
+    {
+        Event::assertDispatched(TrackContentTags::class, fn (TrackContentTags $event) => $event->tags === $tags);
+    }
+}


### PR DESCRIPTION
Adds a `{{ cache_tracker }}` tag for registering a tracked tag directly from a view, instead of rendering an empty dummy partial just to trigger the partial hook.

```antlers
{{ cache_tracker tag="page_builder:projects_latest" }}

{{# or as the tag itself #}}
{{ cache_tracker:page_builder:projects_latest }}
```

This is useful, for example, for a projects block with two modes. A `latest` mode pulls the newest entries via a `{{ collection }}` query, so its output depends on the collection's order. A `selection` mode uses hand-picked entries. Tracking only the `latest` variant previously meant a dummy partial. Now it's inline:

```antlers
{{ if block:query == 'latest' }}
    {{ cache_tracker tag="page_builder:projects_latest" }}
{{ /if }}
```

The `latest` variant gets its own tag so it can be invalidated on its own in a `CollectionTreeSaved` listener when the collection is reordered, while `selection` blocks stay cached.
